### PR TITLE
Cloning an error whose cause is itself

### DIFF
--- a/tests/errors.js
+++ b/tests/errors.js
@@ -17,6 +17,12 @@ export default function (runner, assertEquals) {
         assertEquals(decode(encode(error)), error)
     })
 
+    runner("Error - cause self", () => {
+        const error = new Error("test")
+        error.cause = error
+        assertEquals(decode(encode(error)), error)
+    })
+
     runner("Error - subclasses", () => {
 
         const typeError = new TypeError("test")


### PR DESCRIPTION
- Cloning of the `cause` property of `Error` is not specified.
- whatwg/html#5749
- Chrome fails to clone and `structuredClone(error)` returns `null`.
- Firefox gets stuck in a loop.
- Safari doesn't try to clone `cause` anyway.
- Deno throws a `RangeError` when deserializing.